### PR TITLE
Add polling by git commit sha

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
   plugins: ["prettier"],
   extends: ["eslint:recommended", "prettier"],
   rules: {
+    "no-console": 0,
     "prettier/prettier": [
       "error",
       {

--- a/README.md
+++ b/README.md
@@ -8,10 +8,16 @@ Utility to poll for a build's status on [Percy](https://percy.io).
 
 **NOTE:** Using percy-poller requires a special token. The normal token provided on a project's settings page will not work.
 
-```
+```bash
 npm i -g @percy/poller
 export PERCY_FULL_TOKEN=<your_token>  # Handle this token securely - it must be kept secret
+export PERCY_PROJECT=<your_project>  # From your project settings
+
+# Option 1 - Poll by build_id:
 percy-poller --build_id <your_build_id>
+
+# Option 2 - Poll by git commit sha:
+percy-poller --sha <your_commit_sha>
 ```
 
 * If the build is still processing, it will poll until the build is finished. It retries once a second, with a max of 1000 retries.
@@ -20,12 +26,12 @@ percy-poller --build_id <your_build_id>
 
 ### Sample Build Status
 
-The status is JSON formatted, and has 4 main fields of interest:
+The status is JSON formatted, and has several main fields of interest:
 - state: You probably want to confirm this is 'finished' and not 'failed' or another error condition.  
 - web-url: This is to Percy's web UI for viewing and approving the build.
-- total-comparisons-finished: The total number of comparisons (screenshots) in the build.
-- total-comparisons-diff: The total number of diffs in the build.
-
+- review-state: unreviewed or approved. Builds will be automatically approved if there are no visual changes since last approval.
+- total-snapshots: The total number of snapshots in the build.
+- total-snapshots-unreviewed: The total number of snapshots with changes that are unreviewed.
 
 Sample of a full status:
 
@@ -35,10 +41,15 @@ Sample of a full status:
   "build-number": 632,
   "web-url": "https://percy.io/test/test/builds/430290",
   "state": "finished",
+  "review-state": "approved",
+  "review-state-reason": "no_diffs",
   "is-pull-request": false,
   "pull-request-number": null,
   "pull-request-title": null,
   "user-agent": "Percy/v1 percy-storybook/1.2.6 percy-js/2.4.2 (storybook/^3.2.12 react/^15.6.1; node/v8.4.0)",
+  "total-snapshots": 18,
+  "total-snapshots-unreviewed": 18,
+  "total-comparisons": 36,
   "total-comparisons-finished": 36,
   "total-comparisons-diff": 36,
   "failure-reason": null,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lib"
   ],
   "dependencies": {
-    "percy-client": "^2.5.0",
+    "percy-client": "^2.6.0",
     "yargs": "^7.0.2"
   },
   "devDependencies": {

--- a/src/args.js
+++ b/src/args.js
@@ -5,6 +5,10 @@ export const options = {
     description: 'Percy build id',
     type: 'string',
   },
+  sha: {
+    description: 'Git Commit SHA to find a build for.',
+    type: 'string',
+  },
 };
 
 export const usage = 'Usage: percy-poller --build_id=BUILD_ID';

--- a/src/cli.js
+++ b/src/cli.js
@@ -19,15 +19,12 @@ function retry(client, buildId, numRetries) {
     // Retry with recursion with retries incremented
     setTimeout(getBuild, 1000, client, buildId, numRetries + 1);
   } else {
-    console.error('Retries exceeded. Exiting.');
-    process.exitCode = 1;
+    handleError('Retries exceeded. Exiting.');
   }
 }
 
 function handleUnexpectedStatusCode(response) {
-  console.error('Received an unexpected status code: ', response.statusCode);
-  console.error(response.body);
-  process.exitCode = 1;
+  handleError('Received an unexpected status code: ' + response.statusCode + '\n' + response.body);
 }
 
 function unexpectedBuildResponseBody(response) {
@@ -35,9 +32,10 @@ function unexpectedBuildResponseBody(response) {
 }
 
 function handleUnexpectedBuildResponseBody(response) {
-  console.error('Response body in an unexpected format. Expected JSON with data.attributes');
-  console.error('Response body: ', response.body);
-  process.exitCode = 1;
+  handleError(
+    'Response body in an unexpected format. Expected JSON with data.attributes.' +
+      `\nResponse Body: ${response.body}`,
+  );
 }
 
 function unexpectedBuildsResponseBody(response) {
@@ -45,9 +43,10 @@ function unexpectedBuildsResponseBody(response) {
 }
 
 function handleUnexpectedBuildsResponseBody(response) {
-  console.error('Response body in an unexpected format. Expected JSON with data array of builds.');
-  console.error('Response body: ', response.body);
-  process.exitCode = 1;
+  handleError(
+    'Response body in an unexpected format. Expected JSON with data array of builds.' +
+      `\nResponse Body: ${response.body}`,
+  );
 }
 
 function pollUntilResult(client, buildId, buildAttributes, numRetries) {
@@ -144,8 +143,7 @@ export function run(argv) {
   }
 
   if (!process.env.PERCY_FULL_TOKEN) {
-    console.error('PERCY_FULL_TOKEN environment variable must be set.');
-    process.exitCode = 1;
+    handleError('PERCY_FULL_TOKEN environment variable must be set.');
     return;
   }
 
@@ -158,8 +156,7 @@ export function run(argv) {
 
   if (argv.sha) {
     if (!process.env.PERCY_PROJECT) {
-      console.error('PERCY_PROJECT environment variable must be set when querying by sha.');
-      process.exitCode = 1;
+      handleError('PERCY_PROJECT environment variable must be set when querying by sha.');
       return;
     }
     getBuildForSHA(percyClient, process.env.PERCY_PROJECT, argv.sha);
@@ -167,7 +164,7 @@ export function run(argv) {
     let buildId = argv.build_id;
     getBuild(percyClient, buildId, 0);
   } else {
-    console.error('You must specify either a build_id or sha');
-    process.exitCode = 1;
+    handleError('You must specify either a build_id or sha');
+    return;
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -19,15 +19,14 @@ function retry(client, buildId, numRetries) {
     // Retry with recursion with retries incremented
     setTimeout(getBuild, 1000, client, buildId, numRetries + 1);
   } else {
-    console.error('Retries exceeded. Exiting.'); // eslint-disable-line no-console
+    console.error('Retries exceeded. Exiting.');
     process.exitCode = 1;
   }
 }
 
 function handleUnexpectedStatusCode(response) {
-  // eslint-disable-next-line no-console
   console.error('Received an unexpected status code: ', response.statusCode);
-  console.error(response.body); // eslint-disable-line no-console
+  console.error(response.body);
   process.exitCode = 1;
 }
 
@@ -36,9 +35,7 @@ function unexpectedBuildResponseBody(response) {
 }
 
 function handleUnexpectedBuildResponseBody(response) {
-  // eslint-disable-next-line no-console
   console.error('Response body in an unexpected format. Expected JSON with data.attributes');
-  // eslint-disable-next-line no-console
   console.error('Response body: ', response.body);
   process.exitCode = 1;
 }
@@ -48,9 +45,7 @@ function unexpectedBuildsResponseBody(response) {
 }
 
 function handleUnexpectedBuildsResponseBody(response) {
-  // eslint-disable-next-line no-console
   console.error('Response body in an unexpected format. Expected JSON with data array of builds.');
-  // eslint-disable-next-line no-console
   console.error('Response body: ', response.body);
   process.exitCode = 1;
 }
@@ -60,7 +55,7 @@ function pollUntilResult(client, buildId, buildAttributes, numRetries) {
     retry(client, buildId, numRetries);
   } else {
     let result = JSON.stringify(buildAttributes, null, 2);
-    console.log(result); // eslint-disable-line no-console
+    console.log(result);
   }
 }
 
@@ -97,9 +92,9 @@ function handleBuildsResponse(response, client) {
 
 function handleError(error) {
   if (error.message) {
-    console.error(error.message); // eslint-disable-line no-console
+    console.error(error.message);
   } else {
-    console.error(error); // eslint-disable-line no-console
+    console.error(error);
   }
   // TODO: Could retry on 5XXs 3 times before exiting.
   process.exitCode = 1;
@@ -149,7 +144,6 @@ export function run(argv) {
   }
 
   if (!process.env.PERCY_FULL_TOKEN) {
-    // eslint-disable-next-line no-console
     console.error('PERCY_FULL_TOKEN environment variable must be set.');
     process.exitCode = 1;
     return;
@@ -164,7 +158,6 @@ export function run(argv) {
 
   if (argv.sha) {
     if (!process.env.PERCY_PROJECT) {
-      // eslint-disable-next-line no-console
       console.error('PERCY_PROJECT environment variable must be set when querying by sha.');
       process.exitCode = 1;
       return;
@@ -174,7 +167,6 @@ export function run(argv) {
     let buildId = argv.build_id;
     getBuild(percyClient, buildId, 0);
   } else {
-    // eslint-disable-next-line no-console
     console.error('You must specify either a build_id or sha');
     process.exitCode = 1;
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,11 +10,8 @@ function clientInfo() {
   return `percy-poller/${version}`;
 }
 
-function shouldContinueToPoll(response) {
-  return (
-    response.body.data.attributes.state == 'pending' ||
-    response.body.data.attributes.state == 'processing'
-  );
+function shouldContinueToPoll(buildAttributes) {
+  return buildAttributes.state == 'pending' || buildAttributes.state == 'processing';
 }
 
 function retry(client, buildId, numRetries) {
@@ -34,11 +31,11 @@ function handleUnexpectedStatusCode(response) {
   process.exitCode = 1;
 }
 
-function unexpectedResponseBody(response) {
+function unexpectedBuildResponseBody(response) {
   return !response.body.data || !response.body.data.attributes;
 }
 
-function handleUnexpectedResponseBody(response) {
+function handleUnexpectedBuildResponseBody(response) {
   // eslint-disable-next-line no-console
   console.error('Response body in an unexpected format. Expected JSON with data.attributes');
   // eslint-disable-next-line no-console
@@ -46,25 +43,56 @@ function handleUnexpectedResponseBody(response) {
   process.exitCode = 1;
 }
 
-function handleResponse(response, client, buildId, numRetries) {
+function unexpectedBuildsResponseBody(response) {
+  return !response.body.data || response.body.data == [] || response.body.data[0].type != 'builds';
+}
+
+function handleUnexpectedBuildsResponseBody(response) {
+  // eslint-disable-next-line no-console
+  console.error('Response body in an unexpected format. Expected JSON with data array of builds.');
+  // eslint-disable-next-line no-console
+  console.error('Response body: ', response.body);
+  process.exitCode = 1;
+}
+
+function pollUntilResult(client, buildId, buildAttributes, numRetries) {
+  if (shouldContinueToPoll(buildAttributes)) {
+    retry(client, buildId, numRetries);
+  } else {
+    let result = JSON.stringify(buildAttributes, null, 2);
+    console.log(result); // eslint-disable-line no-console
+  }
+}
+
+function handleBuildResponse(response, client, buildId, numRetries) {
   if (response.statusCode != 200) {
     handleUnexpectedStatusCode(response);
     return;
   }
 
-  if (unexpectedResponseBody(response)) {
-    handleUnexpectedResponseBody(response);
+  if (unexpectedBuildResponseBody(response)) {
+    handleUnexpectedBuildResponseBody(response);
     return;
   }
 
-  if (shouldContinueToPoll(response)) {
-    retry(client, buildId, numRetries);
-  } else {
-    // Received a 200 with a state that indicates processing is finished.
-    // Could be Finished, Failed, Expired. Log and terminate.
-    let result = JSON.stringify(response.body.data.attributes, null, 2);
-    console.log(result); // eslint-disable-line no-console
+  let buildAttributes = response.body.data.attributes;
+  pollUntilResult(client, buildId, buildAttributes, numRetries);
+}
+
+function handleBuildsResponse(response, client) {
+  if (response.statusCode != 200) {
+    handleUnexpectedStatusCode(response);
+    return;
   }
+
+  if (unexpectedBuildsResponseBody(response)) {
+    handleUnexpectedBuildsResponseBody(response);
+    return;
+  }
+
+  let buildId = response.body.data[0].id;
+  let buildAttributes = response.body.data[0].attributes;
+  pollUntilResult(client, buildId, buildAttributes, 0);
 }
 
 function handleError(error) {
@@ -77,11 +105,22 @@ function handleError(error) {
   process.exitCode = 1;
 }
 
+function getBuildForSHA(client, project, sha) {
+  let buildPromise = client.getBuilds(project, {sha: sha});
+  buildPromise
+    .then(response => {
+      handleBuildsResponse(response, client);
+    })
+    .catch(function(error) {
+      handleError(error);
+    });
+}
+
 function getBuild(client, buildId, numRetries) {
   let buildPromise = client.getBuild(buildId);
   buildPromise
     .then(response => {
-      handleResponse(response, client, buildId, numRetries);
+      handleBuildResponse(response, client, buildId, numRetries);
     })
     .catch(function(error) {
       handleError(error);
@@ -95,7 +134,6 @@ export function run(argv) {
     .help()
     .alias('help', 'h')
     .options(args.options)
-    .demandOption(['build_id'], 'Please provide a build_id.')
     .epilogue(args.docs).argv;
 
   if (argv.help) {
@@ -123,6 +161,21 @@ export function run(argv) {
     apiUrl,
     clientInfo: clientInfo(),
   });
-  let buildId = argv.build_id;
-  getBuild(percyClient, buildId, 0);
+
+  if (argv.sha) {
+    if (!process.env.PERCY_PROJECT) {
+      // eslint-disable-next-line no-console
+      console.error('PERCY_PROJECT environment variable must be set when querying by sha.');
+      process.exitCode = 1;
+      return;
+    }
+    getBuildForSHA(percyClient, process.env.PERCY_PROJECT, argv.sha);
+  } else if (argv.build_id) {
+    let buildId = argv.build_id;
+    getBuild(percyClient, buildId, 0);
+  } else {
+    // eslint-disable-next-line no-console
+    console.error('You must specify either a build_id or sha');
+    process.exitCode = 1;
+  }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -24,7 +24,10 @@ function retry(client, buildId, numRetries) {
 }
 
 function handleUnexpectedStatusCode(response) {
-  handleError('Received an unexpected status code: ' + response.statusCode + '\n' + response.body);
+  handleError(
+    `Received an unexpected status code: ${response.statusCode}` +
+      `\nResponse Body: ${JSON.stringify(response.body)}`,
+  );
 }
 
 function unexpectedBuildResponseBody(response) {
@@ -34,18 +37,20 @@ function unexpectedBuildResponseBody(response) {
 function handleUnexpectedBuildResponseBody(response) {
   handleError(
     'Response body in an unexpected format. Expected JSON with data.attributes.' +
-      `\nResponse Body: ${response.body}`,
+      `\nResponse Body: ${JSON.stringify(response.body)}`,
   );
 }
 
 function unexpectedBuildsResponseBody(response) {
-  return !response.body.data || response.body.data == [] || response.body.data[0].type != 'builds';
+  return (
+    !response.body.data || response.body.data.length == 0 || response.body.data[0].type != 'builds'
+  );
 }
 
 function handleUnexpectedBuildsResponseBody(response) {
   handleError(
     'Response body in an unexpected format. Expected JSON with data array of builds.' +
-      `\nResponse Body: ${response.body}`,
+      `\nResponse Body: ${JSON.stringify(response.body)}`,
   );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2223,9 +2223,9 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-percy-client@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/percy-client/-/percy-client-2.5.0.tgz#54f981a827013c7d7a9e9fdb289ec9671f0f8bea"
+percy-client@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/percy-client/-/percy-client-2.6.0.tgz#df63a63256ba0e428b6a22ee5fc4dec482ab94a2"
   dependencies:
     base64-js "^1.1.2"
     bluebird "^3.5.1"


### PR DESCRIPTION
Adds option to poll by git commit sha:

`percy-poller --sha <your_commit_sha>`

Have tested this manually by sha with a build that's still receiving and a build that's finished.   Have also manually tested polling by build_id to ensure that still works.

Have also added new build attributes to the README.

## Dependencies
Depends on this percy-js PR being shipped first: https://github.com/percy/percy-js/pull/26

## Testing
Until the new percy-client npm module is released, this can be tested by updating the percy-js dependency in the package.json with the file protocol, assuming you have percy-js repo checked out on the add-get-builds branch:
`"percy-client": "file:/percy/source/percy-js",`

